### PR TITLE
Updated vault.trustedEndpoints section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ TODO
 
 The following settings are supported
 
-* `vault.trustedEndpoints` : A collection of authorities (username and port) for which strict SSL checking will be skipped.
+* `vault.trustedEndpoints` : A collection of authorities (username and port, or `servername:port` in case of Native authentication) for which strict SSL checking will be skipped.
 * `vault.clipboardTimeout` : A duration (in seconds) after which clipboard contents will be cleared. When set to `0`, clipboard clearing will be disabled. Defaults to `60`.
 
 -----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
-Native authentication mechanism connects using servername and port.  It uses token mechanism.
-Updated vault.trustedEndpoints section within README.md to explicitly call out usage of servername:port format